### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -90,7 +90,7 @@ class Plugin extends BasePlugin
         /**
          * Base plus twig extension
          */
-        Craft::$app->view->twig->addExtension(new \fvaldes33\plus\twigextensions\PlusTwigExtension());
+        Craft::$app->view->registerTwigExtension(new \fvaldes33\plus\twigextensions\PlusTwigExtension());
 
         /**
          * Settings
@@ -117,7 +117,7 @@ class Plugin extends BasePlugin
 
             $twigextension = $this->getSettings()->twigextension;
             if ($twigextension) {
-                Craft::$app->view->twig->addExtension(new $twigextension);    
+                Craft::$app->view->registerTwigExtension(new $twigextension);    
             }
         }
 


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.